### PR TITLE
Upgrade to fs-fake-targets v0.1.1

### DIFF
--- a/._fake/paket.dependencies
+++ b/._fake/paket.dependencies
@@ -2,4 +2,4 @@ source https://nuget.org/api/v2
 
 nuget fake
 nuget NUnit.Runners 2.6.4
-nuget FSharp.FakeTargets 0.1.0
+nuget FSharp.FakeTargets 0.1.1

--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -2,5 +2,5 @@ NUGET
   remote: https://www.nuget.org/api/v2
   specs:
     FAKE (4.25.4)
-    FSharp.FakeTargets (0.1)
+    FSharp.FakeTargets (0.1.1)
     NUnit.Runners (2.6.4)


### PR DESCRIPTION
This fixes the namespace issues which are currently causing all the fake stuff to be broken.