### PR TITLE
Set values in assemblyinfo files

### DIFF
--- a/src/FSharpAssemblyInfoUtils/assemblyInfoVersion.fs
+++ b/src/FSharpAssemblyInfoUtils/assemblyInfoVersion.fs
@@ -23,8 +23,7 @@ module AssemblyInfo =
     _GetAssemblyAttributeValuePattern "AssemblyInformationalVersion"
 
 
-  let private _IsSingleLineComment line =
-    "^//" >** line
+  let private _IsSingleLineComment line = "^//" >** line
 
   let private _IsAssemblyAttribute line =
     "^\[\<?assembly\:.+\(.+\)\>?\]$" >** line
@@ -70,23 +69,27 @@ module AssemblyInfo =
     File.ReadAllLines(filePath)
     |> ParseInformationalVersionStringFromLines
 
-  // TODO: Clean this up a bit ================================================
+  // TODO: Clean this up ======================================================
+
+  let _SetAttributeParametersValue attributeName line (attributeValue: string) =
+    let pattern = String.Format(@"({0}\("").+(""\))", [| attributeName |])
+    System.Text.RegularExpressions.Regex.Replace(line, pattern, "$1" + attributeValue + "$2")
 
   // Note: the type annotations on these are temporary
-  let private _SetAssemblyVersionValue (value: string) =
-    "TODO"
+  let private _SetAssemblyVersionValue line value =
+    _SetAttributeParametersValue "AssemblyVersion" line value
 
-  let private _SetAssemblyFileVersionValue (value: string) =
-    "TODO"
+  let private _SetAssemblyFileVersionValue line value =
+    _SetAttributeParametersValue "AssemblyFileVersion" line value
 
-  let private _SetAssemblyInformationalVersionValue (value: string) =
-    "TODO"
+  let private _SetAssemblyInformationalVersionValue line value =
+    _SetAttributeParametersValue "AssemblyInformationalVersion" line value
 
   let _SetVersionValue matchLine mutateLine (fileContents: string) versionString =
     fileContents.Split [| '\n' |]
     |> Seq.map (fun line ->
-         if matchLine line then mutateLine versionString
-         else line
+          if matchLine line then mutateLine line versionString
+          else line
       )
 
   let SetAssemblyVersion = _SetVersionValue _IsAssemblyVersionAttribute _SetAssemblyVersionValue

--- a/src/FSharpAssemblyInfoUtils/assemblyInfoVersion.fs
+++ b/src/FSharpAssemblyInfoUtils/assemblyInfoVersion.fs
@@ -22,6 +22,7 @@ module AssemblyInfo =
   let private _assemblyInformationalVersionPattern =
     _GetAssemblyAttributeValuePattern "AssemblyInformationalVersion"
 
+
   let private _IsSingleLineComment line =
     "^//" >** line
 
@@ -30,6 +31,14 @@ module AssemblyInfo =
 
   let private _IsVersionAttribute line =
     (not (_IsSingleLineComment line)) && ("Version\(.+\)\>?\]$" >** line)
+
+  let private _IsAssemblyVersionAttribute line =
+    let pattern = "AssemblyVersion\(\"(.+)\"\)"
+    (not (_IsSingleLineComment line)) && (pattern >** line)
+
+  let private _IsAssemblyFileVersionAttribute line =
+    let pattern = "AssemblyFileVersion\(\"(.+)\"\)"
+    (not (_IsSingleLineComment line)) && (pattern >** line)
 
   let private _IsAssemblyInformationalVersionAttribute line =
     let pattern = "AssemblyInformationalVersion\(\"(.+)\"\)"
@@ -60,3 +69,26 @@ module AssemblyInfo =
   let GetAssemblyInformationalVersionString filePath =
     File.ReadAllLines(filePath)
     |> ParseInformationalVersionStringFromLines
+
+  // TODO: Clean this up a bit ================================================
+
+  // Note: the type annotations on these are temporary
+  let private _SetAssemblyVersionValue (value: string) =
+    "TODO"
+
+  let private _SetAssemblyFileVersionValue (value: string) =
+    "TODO"
+
+  let private _SetAssemblyInformationalVersionValue (value: string) =
+    "TODO"
+
+  let _SetVersionValue matchLine mutateLine (fileContents: string) versionString =
+    fileContents.Split [| '\n' |]
+    |> Seq.map (fun line ->
+         if matchLine line then mutateLine versionString
+         else line
+      )
+
+  let SetAssemblyVersion = _SetVersionValue _IsAssemblyVersionAttribute _SetAssemblyVersionValue
+  let SetAssemblyFileVersion = _SetVersionValue _IsAssemblyFileVersionAttribute _SetAssemblyFileVersionValue
+  let SetAssemblyInformationalVersion = _SetVersionValue _IsAssemblyInformationalVersionAttribute _SetAssemblyInformationalVersionValue


### PR DESCRIPTION
#### Changes
With this PR, a developer can now do the following:

0. Read the AssemblyInformationalVersion from an AssemblyInformation.(fs|cs) file
0. Do whatever he/she wants with that version string
0. Set the `Assembly{,File,Informational}Version` attribute in those file contents
  * A new string is returned, nothing is actually modified.
0. The developer can then do whatever they please with that updated string.
  * Typically, that will be writing this string back as the contents of the original `AssemblyInformation.(fs|cs)` file it was read from, but this does not necessarily have to be the case.

#### Notes
There's a fair amount of cleanup /test coverage that could be done in here, but I'd prefer to do that as a followup once we've tried this out, as it has been verified in the REPL to do what we expect it to.