### PR TITLE
Fix replace string for setting attribute values

### DIFF
--- a/src/FSharpAssemblyInfoUtils/assemblyInfoVersion.fs
+++ b/src/FSharpAssemblyInfoUtils/assemblyInfoVersion.fs
@@ -73,7 +73,7 @@ module AssemblyInfo =
 
   let _SetAttributeParametersValue attributeName line (attributeValue: string) =
     let pattern = String.Format(@"({0}\("").+(""\))", [| attributeName |])
-    System.Text.RegularExpressions.Regex.Replace(line, pattern, "$1" + attributeValue + "$2")
+    System.Text.RegularExpressions.Regex.Replace(line, pattern, "${1}" + attributeValue + "${2}")
 
   // Note: the type annotations on these are temporary
   let private _SetAssemblyVersionValue line value =


### PR DESCRIPTION
$1 needed to be ${1}, because the distinction between literal numbers
and variables for capture groups wasn't happening properly.

This basically boils down to the difference between these two options:

##### Before
```
$10.1.1$2
```

##### After
```
${1}0.1.1${2}
```

What should have been `$1` at the beginning of the replace string was actually getting parsed as `$10`