### PR TITLE
Fix eol bug

### DIFF
--- a/._fake/paket.dependencies
+++ b/._fake/paket.dependencies
@@ -1,5 +1,5 @@
 source https://nuget.org/api/v2
 
-nuget fake
+nuget FSharp.FakeTargets 0.3.0
 nuget NUnit.Runners 2.6.4
-nuget FSharp.FakeTargets 0.2.0
+nuget fake

--- a/._fake/paket.lock
+++ b/._fake/paket.lock
@@ -2,5 +2,5 @@ NUGET
   remote: https://www.nuget.org/api/v2
   specs:
     FAKE (4.25.4)
-    FSharp.FakeTargets (0.2)
+    FSharp.FakeTargets (0.3)
     NUnit.Runners (2.6.4)

--- a/src/FSharpAssemblyInfoUtils/assemblyInfoVersion.fs
+++ b/src/FSharpAssemblyInfoUtils/assemblyInfoVersion.fs
@@ -87,6 +87,7 @@ module AssemblyInfo =
 
   let _SetVersionValue matchLine mutateLine (fileContents: string) versionString =
     fileContents.Split [| '\n' |]
+    |> Seq.map trim
     |> Seq.map (fun line ->
           if matchLine line then mutateLine line versionString
           else line


### PR DESCRIPTION
There are really two changes in this PR. They are as follows.

#### Fix accumulating whitespace @ EOL issue
We need to trim each line after we split the AssemblyInfo file's contents. Otherwise, we'll get whitespace characters building up at the end of each line.

#### Upgrade fake targets dependency -> 0.3.0
This gives us the version-incrementing targets we've been waiting for!