### PR TITLE
Scope msbuild artifacts under src/

### DIFF
--- a/._fake/config.fsx
+++ b/._fake/config.fsx
@@ -17,7 +17,7 @@ module Source =
 module Build =
   let TestAssemblies = !! "tests/**/*.Tests.dll" -- "**/obj/**/*.Tests.dll"
   let DotNetVersion = "4.5"
-  let MSBuildArtifacts = !! "**/bin/**.*" ++ "**/obj/**/*.*"
+  let MSBuildArtifacts = !! "src/**/bin/**.*" ++ "src/**/obj/**/*.*"
 
 module Nuget =
   let ApiEnvVar = "DAT_NET_NUGET_API_KEY"


### PR DESCRIPTION
I'm not sure why we didn't scope these globes under the `src/` directory, or if there was even a reason in the first place.

The `msbuild` and `package` targets still work the same way, so I think we should be fine with this change.