### PR TITLE
Assemblyinfo tests

### DIFF
--- a/._fake/config.fsx
+++ b/._fake/config.fsx
@@ -15,7 +15,7 @@ module Source =
   let SolutionFile = !! (Path.Combine(RootDir, "*.sln"))
 
 module Build =
-  let TestAssemblies = !! "tests/**/*.Tests.dll" -- "**/obj/**/*.Tests.dll"
+  let TestAssemblies = !! "tests/**/bin/Release/*.Tests.dll"
   let DotNetVersion = "4.5"
   let MSBuildArtifacts = !! "src/**/bin/**.*" ++ "src/**/obj/**/*.*"
 

--- a/tests/FSharpAssemblyInfoUtils.Tests/assemblyInfoVersionTests.fs
+++ b/tests/FSharpAssemblyInfoUtils.Tests/assemblyInfoVersionTests.fs
@@ -4,168 +4,19 @@ open System
 open NUnit.Framework
 open FsUnit
 open datNET.AssemblyInfo
+open System.IO
 
-let assemblyInfoFsContent =
-    @"
-namespace FSharpAssemblyInfoUtils.AssemblyInfo
+let _readDataFile fileName =
+  let dataDir = Path.Combine [| Directory.GetCurrentDirectory() ; ".." ; ".." ; "data" |]
+  let filePath = Path.Combine [| dataDir ; fileName |]
+  
+  File.ReadAllText filePath
 
-open System.Reflection
-open System.Runtime.CompilerServices
-open System.Runtime.InteropServices
+let assemblyInfoFsContent = _readDataFile "AssemblyInfo.fs"
+let withoutFsInformationalVersion = _readDataFile "AssemblyInfoNoInformationalVersion.fs"
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[<assembly: AssemblyTitle(""ExampleTitle"")>]
-[<assembly: AssemblyDescription(""ExampleDescription"")>]
-[<assembly: AssemblyCompany(""ExampleCompany"")>]
-[<assembly: AssemblyProduct(""ExampleProduct"")>]
-[<assembly: AssemblyCopyright(""Copyright ©  2016"")>]
-
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[<assembly: ComVisible(false)>]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[<assembly: Guid(""7cff4eba-acd5-45b8-bbcc-a3346c41910c"")>]
-
-// Version information for an assembly consists of the following four values:
-//
-//       Major Version
-//       Minor Version
-//       Build Number
-//       Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [<assembly: AssemblyVersion(""1.0.*"")>]
-[<assembly: AssemblyVersion(""1.0.0.0"")>]
-[<assembly: AssemblyFileVersion(""1.0.0.0"")>]
-[<assembly: AssemblyInformationalVersion(""1.0.0"")>]
-
-do
-    ()
-    "
-
-let withoutFsInformationalVersion =
-    @"
-namespace FSharpAssemblyInfoUtils.AssemblyInfo
-
-open System.Reflection
-open System.Runtime.CompilerServices
-open System.Runtime.InteropServices
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[<assembly: AssemblyTitle(""ExampleTitle"")>]
-[<assembly: AssemblyDescription(""ExampleDescription"")>]
-[<assembly: AssemblyCompany(""ExampleCompany"")>]
-[<assembly: AssemblyProduct(""ExampleProduct"")>]
-[<assembly: AssemblyCopyright(""Copyright ©  2016"")>]
-
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[<assembly: ComVisible(false)>]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[<assembly: Guid(""7cff4eba-acd5-45b8-bbcc-a3346c41910c"")>]
-
-// Version information for an assembly consists of the following four values:
-//
-//       Major Version
-//       Minor Version
-//       Build Number
-//       Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [<assembly: AssemblyVersion(""1.0.*"")>]
-[<assembly: AssemblyVersion(""1.0.0.0"")>]
-[<assembly: AssemblyFileVersion(""1.0.0.0"")>]
-
-do
-    ()
-    "
-
-let assemblyInfoCsContent =
-    @"
-using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle(""ExampleTitle"")]
-[assembly: AssemblyDescription(""ExampleDescription"")]
-[assembly: AssemblyCompany(""ExampleCompany"")]
-[assembly: AssemblyProduct(""ExampleProduct"")]
-[assembly: AssemblyCopyright(""Copyright ©  2014"")]
-
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid(""60fcbd4d-0b5a-4daf-bce8-a14c97cac246"")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion(""1.0.*"")]
-[assembly: AssemblyVersion(""1.0.0.0"")]
-[assembly: AssemblyFileVersion(""1.0.0.0"")]
-[assembly: AssemblyInformationalVersion(""1.0.0"")]
-    "
-
-let withoutCsInformationalVersion =
-    @"
-using System.Reflection;
-using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle(""ExampleTitle"")]
-[assembly: AssemblyDescription(""ExampleDescription"")]
-[assembly: AssemblyCompany(""ExampleCompany"")]
-[assembly: AssemblyProduct(""ExampleProduct"")]
-[assembly: AssemblyCopyright(""Copyright ©  2014"")]
-
-
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid(""60fcbd4d-0b5a-4daf-bce8-a14c97cac246"")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion(""1.0.*"")]
-[assembly: AssemblyVersion(""1.0.0.0"")]
-[assembly: AssemblyFileVersion(""1.0.0.0"")]
-    "
+let assemblyInfoCsContent = _readDataFile "AssemblyInfo.cs"
+let withoutCsInformationalVersion = _readDataFile "AssemblyInfoNoInformationalVersion.cs"
 
 [<Test>]
 let ``parse AssemblyInformationalVersion (C#)`` () =

--- a/tests/FSharpAssemblyInfoUtils.Tests/data/AssemblyInfo.cs
+++ b/tests/FSharpAssemblyInfoUtils.Tests/data/AssemblyInfo.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ExampleTitle")]
+[assembly: AssemblyDescription("ExampleDescription")]
+[assembly: AssemblyCompany("ExampleCompany")]
+[assembly: AssemblyProduct("ExampleProduct")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("60fcbd4d-0b5a-4daf-bce8-a14c97cac246")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]

--- a/tests/FSharpAssemblyInfoUtils.Tests/data/AssemblyInfo.fs
+++ b/tests/FSharpAssemblyInfoUtils.Tests/data/AssemblyInfo.fs
@@ -1,0 +1,40 @@
+namespace FSharpAssemblyInfoUtils.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("ExampleTitle")>]
+[<assembly: AssemblyDescription("ExampleDescription")>]
+[<assembly: AssemblyCompany("ExampleCompany")>]
+[<assembly: AssemblyProduct("ExampleProduct")>]
+[<assembly: AssemblyCopyright("Copyright ©  2016")>]
+
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("7cff4eba-acd5-45b8-bbcc-a3346c41910c")>]
+
+// Version information for an assembly consists of the following four values:
+//
+//       Major Version
+//       Minor Version
+//       Build Number
+//       Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+[<assembly: AssemblyInformationalVersion("1.0.0")>]
+
+do
+    ()

--- a/tests/FSharpAssemblyInfoUtils.Tests/data/AssemblyInfoNoInformationalVersion.cs
+++ b/tests/FSharpAssemblyInfoUtils.Tests/data/AssemblyInfoNoInformationalVersion.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ExampleTitle")]
+[assembly: AssemblyDescription("ExampleDescription")]
+[assembly: AssemblyCompany("ExampleCompany")]
+[assembly: AssemblyProduct("ExampleProduct")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("60fcbd4d-0b5a-4daf-bce8-a14c97cac246")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/FSharpAssemblyInfoUtils.Tests/data/AssemblyInfoNoInformationalVersion.fs
+++ b/tests/FSharpAssemblyInfoUtils.Tests/data/AssemblyInfoNoInformationalVersion.fs
@@ -1,0 +1,39 @@
+namespace FSharpAssemblyInfoUtils.AssemblyInfo
+
+open System.Reflection
+open System.Runtime.CompilerServices
+open System.Runtime.InteropServices
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[<assembly: AssemblyTitle("ExampleTitle")>]
+[<assembly: AssemblyDescription("ExampleDescription")>]
+[<assembly: AssemblyCompany("ExampleCompany")>]
+[<assembly: AssemblyProduct("ExampleProduct")>]
+[<assembly: AssemblyCopyright("Copyright ©  2016")>]
+
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[<assembly: ComVisible(false)>]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[<assembly: Guid("7cff4eba-acd5-45b8-bbcc-a3346c41910c")>]
+
+// Version information for an assembly consists of the following four values:
+//
+//       Major Version
+//       Minor Version
+//       Build Number
+//       Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [<assembly: AssemblyVersion("1.0.*")>]
+[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyFileVersion("1.0.0.0")>]
+
+do
+    ()


### PR DESCRIPTION
### Changes
##### Move the sample data in the tests out to files
This has two benefits:

0. The source code for the tests is now much nicer to read
0. The code being tested is very much intended for modifying file contents, so it's kind of just appropriate

This is why I think it's alright. Normally I'd be pretty upset that tests are interacting with the filesystem.

##### Update the test assemblies glob in config.fsx
We were having double test runs, because it was matching stuff in both bin/Debug **and** in bin/Release.

Chose to only look at what's in release, because that's what `msbuild`, the `test` target's prerequisite, deals with.