### PR TITLE
Lib practices

### DIFF
--- a/src/FSharpAssemblyInfoUtils/FSharpAssemblyInfoUtils.fsproj
+++ b/src/FSharpAssemblyInfoUtils/FSharpAssemblyInfoUtils.fsproj
@@ -10,7 +10,7 @@
     <RootNamespace>FSharpAssemblyInfoUtils</RootNamespace>
     <AssemblyName>FSharpAssemblyInfoUtils</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>FSharpAssemblyInfoUtils</Name>
     <TargetFrameworkProfile />

--- a/src/FSharpAssemblyInfoUtils/FSharpAssemblyInfoUtils.fsproj
+++ b/src/FSharpAssemblyInfoUtils/FSharpAssemblyInfoUtils.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FSharpAssemblyInfoUtils</RootNamespace>
     <AssemblyName>FSharpAssemblyInfoUtils</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>FSharpAssemblyInfoUtils</Name>

--- a/tests/FSharpAssemblyInfoUtils.Tests/App.config
+++ b/tests/FSharpAssemblyInfoUtils.Tests/App.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -8,4 +8,7 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
 </configuration>

--- a/tests/FSharpAssemblyInfoUtils.Tests/FSharpAssemblyInfoUtils.Tests.fsproj
+++ b/tests/FSharpAssemblyInfoUtils.Tests/FSharpAssemblyInfoUtils.Tests.fsproj
@@ -9,7 +9,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FSharpAssemblyInfoUtils.Tests</RootNamespace>
     <AssemblyName>FSharpAssemblyInfoUtils.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Name>FSharpAssemblyInfoUtils.Tests</Name>


### PR DESCRIPTION
Following advice from [here](https://fsharp.github.io/2015/04/18/fsharp-core-notes.html)
>F# ecosystem libraries should generally target the earliest, most portable version of FSharp.Core feasible.

>If your library is part of an ecosystem, it can be helpful to target the earliest, most widespread language version and the earliest (4.0+) and most portable profiles of the .NET Framework feasible.